### PR TITLE
Export entire env directory

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -25,7 +25,7 @@ source ${build_pack_dir}/lib/build.sh
 head "Loading configuration and environment"
 load_previous_npm_node_versions
 load_config
-export_rails_env
+export_env_dir
 
 cached_node=$cache_dir/node-v$node_version-linux-x64.tar.gz
 

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -45,14 +45,14 @@ load_config() {
   info "* Config vars ${config_vars_to_export[*]}"
 }
 
-export_rails_env() {
- if [ -z "${RAILS_ENV}" ]; then
-	 if [ -d $env_dir ] && [ -f $env_dir/RAILS_ENV ]; then
-		 export RAILS_ENV=$(cat $env_dir/RAILS_ENV)
-	 else
-		 export RAILS_ENV=production
-	 fi
- fi
-
- info "* RAILS_ENV=${RAILS_ENV}"
+export_env_dir() {
+  whitelist_regex=${2:-''}
+  blacklist_regex=${3:-'^(PATH|GIT_DIR|CPATH|CPPATH|LD_PRELOAD|LIBRARY_PATH)$'}
+  if [ -d "$env_dir" ]; then
+    for e in $(ls $env_dir); do
+      echo "$e" | grep -E "$whitelist_regex" | grep -qvE "$blacklist_regex" &&
+      export "$e=$(cat $env_dir/$e)"
+      :
+    done
+  fi
 }


### PR DESCRIPTION
Some common gems will verify that important configurations are set from environment variables when initializing.  In particular, [Devise](https://github.com/plataformatec/devise) checks that the `config.secret_key` is set:

```
rake aborted!
Devise.secret_key was not set. Please add the following to your Devise initializer:
config.secret_key = '1c9465f937a0fe64d4d3d6fbe6884208f202dcbc30e42912956a42084f806bba32b874596280f5e41b5a39bdefb3fc19c2122e4f9f9c41a6bda67e0f8bfc7597'
```

Since the breakfast compilation rake tasks require the Rails environment, these checks are going to get run.  In theory, I could set a fallback value, but that seems dangerous and defeats the purpose of having the check.

This PR loads all the environment variables so that these checks can still pass.

The function for loading the env dir was lifted from the heroku docs: https://devcenter.heroku.com/articles/buildpack-api